### PR TITLE
Output one instance to OutputDebugString

### DIFF
--- a/googletest/src/gtest_main.cc
+++ b/googletest/src/gtest_main.cc
@@ -32,7 +32,8 @@
 #include "gtest/gtest.h"
 
 GTEST_API_ int main(int argc, char **argv) {
-  printf("Running main() from gtest_main.cc\n");
+  sprintf(output, "Running main() from gtest_main.cc\n");
+  OutputDebugString(output);
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
https://github.com/google/googletest/issues/1039

Responding to issue 1039 with one example of redirecting output to OutputDebugString.