### PR TITLE
Add -Werror flag to Makefile

### DIFF
--- a/googletest/make/Makefile
+++ b/googletest/make/Makefile
@@ -25,7 +25,7 @@ USER_DIR = ../samples
 CPPFLAGS += -isystem $(GTEST_DIR)/include
 
 # Flags passed to the C++ compiler.
-CXXFLAGS += -g -Wall -Wextra -pthread
+CXXFLAGS += -g -Wall -Werror -Wextra -pthread
 
 # All tests produced by this Makefile.  Remember to add new tests you
 # created to the list.


### PR DESCRIPTION
https://github.com/google/googletest/issues/1039

Addressing issue 1039, adding the -Werror flag so that the program stops on all warnings and marks them as errors.